### PR TITLE
adapt `Age` to current month (11/2020)

### DIFF
--- a/tests/testthat/test-DEG_DE.R
+++ b/tests/testthat/test-DEG_DE.R
@@ -69,7 +69,7 @@ expect_equal(
     'Hearing Impairment' = 1,
     'Type of Hearing Impairment' = "Tinnitus",
     Gender = 1,
-    Age = 260,
+    Age = 261,
     Nationality = "DE",
     'Country Formative Years' = "TR",
     'First Language' = "tr",

--- a/tests/testthat/test-DEG_DE_no-q3.R
+++ b/tests/testthat/test-DEG_DE_no-q3.R
@@ -64,7 +64,7 @@ expect_equal(
     'Hearing Impairment' = 2,
     'Type of Hearing Impairment' = "",
     Gender = 1,
-    Age = 260,
+    Age = 261,
     Nationality = "DE",
     'Country Formative Years' = "TR",
     'First Language' = "tr",

--- a/tests/testthat/test-DEG_DE_q3_umlaut_and_punctuation.R
+++ b/tests/testthat/test-DEG_DE_q3_umlaut_and_punctuation.R
@@ -69,7 +69,7 @@ expect_equal(
     'Hearing Impairment' = 1,
     'Type of Hearing Impairment' = "Ähm, hab ich mich verklickt?!",
     Gender = 1,
-    Age = 260,
+    Age = 261,
     Nationality = "DE",
     'Country Formative Years' = "TR",
     'First Language' = "tr",

--- a/tests/testthat/test-DEG_DE_subscales_Best-Shot_Hearing-Impairment_Age_Handedness.R
+++ b/tests/testthat/test-DEG_DE_subscales_Best-Shot_Hearing-Impairment_Age_Handedness.R
@@ -45,7 +45,7 @@ expect_equal(
     'Best Shot' = 1,
     'Hearing Impairment' = 1,
     'Type of Hearing Impairment' = "Tinnitus",
-    Age = 260,
+    Age = 261,
     Handedness = c(1, 2)
   )
 )

--- a/tests/testthat/test-DEG_EN.R
+++ b/tests/testthat/test-DEG_EN.R
@@ -68,7 +68,7 @@ expect_equal(
     'Hearing Impairment' = 1,
     'Type of Hearing Impairment' = "Tinnitus",
     Gender = 1,
-    Age = 260,
+    Age = 261,
     Nationality = "UK",
     'Country Formative Years' = "UK",
     'First Language' = "ar",

--- a/tests/testthat/test-DEG_EN_leap_year.R
+++ b/tests/testthat/test-DEG_EN_leap_year.R
@@ -68,7 +68,7 @@ expect_equal(
     'Hearing Impairment' = 1,
     'Type of Hearing Impairment' = "Tinnitus",
     Gender = 1,
-    Age = 248,
+    Age = 249,
     Nationality = "UK",
     'Country Formative Years' = "UK",
     'First Language' = "ar",

--- a/tests/testthat/test-DEG_EN_no-q3.R
+++ b/tests/testthat/test-DEG_EN_no-q3.R
@@ -63,7 +63,7 @@ expect_equal(
     'Hearing Impairment' = 2,
     'Type of Hearing Impairment' = "",
     Gender = 1,
-    Age = 260,
+    Age = 261,
     Nationality = "UK",
     'Country Formative Years' = "UK",
     'First Language' = "ar",

--- a/tests/testthat/test-DEG_EN_no_second_language.R
+++ b/tests/testthat/test-DEG_EN_no_second_language.R
@@ -67,7 +67,7 @@ expect_equal(
     'Hearing Impairment' = 1,
     'Type of Hearing Impairment' = "Tinnitus",
     Gender = 1,
-    Age = 260,
+    Age = 261,
     Nationality = "UK",
     'Country Formative Years' = "UK",
     'First Language' = "ar",

--- a/tests/testthat/test-DEG_EN_other_countries.R
+++ b/tests/testthat/test-DEG_EN_other_countries.R
@@ -70,7 +70,7 @@ expect_equal(
     'Hearing Impairment' = 1,
     'Type of Hearing Impairment' = "Tinnitus",
     Gender = 1,
-    Age = 260,
+    Age = 261,
     Nationality = "VN",
     'Country Formative Years' = "OTHER",
     'First Language' = "ar",


### PR DESCRIPTION
This pull request changes all values of `Age` in the testthat tests of DEG, so they correspond to the current month of November 2020.